### PR TITLE
[Feature] Enabling nagios monitoring for heat barclamp.

### DIFF
--- a/chef/cookbooks/heat/attributes/default.rb
+++ b/chef/cookbooks/heat/attributes/default.rb
@@ -16,7 +16,7 @@
 case node["platform"]
     when "ubuntu" 
         default[:heat][:platform] = {
-            :packages => ["heat-api","heat-api-cfn","heat-api-cloudwatch","python-heat","heat-common","python-heatclient"],
+            :packages => ["heat-engine","heat-api","heat-api-cfn","heat-api-cloudwatch","python-heat","heat-common","python-heatclient"],
             :services => ["heat-engine","heat-api","heat-api-cfn","heat-api-cloudwatch"],
             :aux_dirs => ["/var/cache/heat","/etc/heat/environment.d"]
         }

--- a/chef/cookbooks/heat/templates/default/heat_nrpe.cfg.erb
+++ b/chef/cookbooks/heat/templates/default/heat_nrpe.cfg.erb
@@ -1,4 +1,4 @@
-% @heat_services.each do |s| %>
+<% @heat_services.each do |s| %>
 command[check_<%= s %>]=/usr/lib/nagios/plugins/check_procs -w 2:10 -c 1:100 -a "<%= s %>"
 <% end unless @heat_services.nil? %>
 

--- a/chef/roles/heat-server.rb
+++ b/chef/roles/heat-server.rb
@@ -2,8 +2,8 @@ name "heat-server"
 description "Heat Server Role"
 run_list(
          "recipe[heat::server]",
-         "recipe[heat::common]"
-         
+         "recipe[heat::common]",
+         "recipe[heat::monitor]"
 )
 default_attributes()
 override_attributes()

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -53,6 +53,7 @@ debs:
     - heat-api-cfn
     - heat-api-cloudwatch
     - heat-common
+    - heat-engine
 
 locale_additions:
   en:


### PR DESCRIPTION
Following changes were made:
1. Adding back monitoring feature for barclamp-heat.
2. Moving "heat-engine" package back to node attributes and "crowbar.yml".
