### PR TITLE
set auth_host in heat.conf

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -694,7 +694,7 @@ bind_port=<%= node[:heat][:api][:cfn_port] %>
 
 # Host providing the admin Identity API endpoint (string
 # value)
-#auth_host=
+auth_host=<%= @keystone_host %>
 
 # Port of the admin Identity API endpoint (integer value)
 #auth_port=


### PR DESCRIPTION
when SSL is enabled, the certificate fails to validate against the default
localhost

Fixes (bnc#854753)
