### PR TITLE
Increase http read timeout from 500 to 3600

### DIFF
--- a/bin/crowbar_heat
+++ b/bin/crowbar_heat
@@ -17,5 +17,6 @@
 
 require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
 @barclamp = "heat"
+@timeout = 3600
 
 main


### PR DESCRIPTION
Prevent the crowbar client raising a timeout exception
as heat deployment time exceeds that timeout.
