### PR TITLE
Heat-engine doesn't use oslo's db api yet

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -7,6 +7,7 @@
 # The SQLAlchemy connection string used to connect to the
 # database (string value)
 #sql_connection=mysql://heat:heat@localhost/heat
+sql_connection=<%= @database_connection %>
 
 # timeout before idle sql connections are reaped (integer
 # value)


### PR DESCRIPTION
So we need to set db access credentials in two places.
