### PR TITLE
Move lock_path to /var/run

### DIFF
--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -155,7 +155,7 @@ auth_encryption_key=%ENCRYPTION_KEY%
 #disable_process_locking=false
 
 # Directory to use for lock files. (string value)
-lock_path=/var/lock/heat
+lock_path=/var/run/heat
 
 
 #


### PR DESCRIPTION
/var/lock is blacklisted on openSUSE
