### PR TITLE
Fix registering heat domain when keystone is deployed with HA

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -185,7 +185,7 @@ bash "register heat domain" do
   user "root"
   code <<-EOF
 
-    OS_URL="#{KeystoneHelper.service_URL(node, node[:fqdn], node["keystone"]["api"]["service_port"])}/v3"
+    OS_URL="#{keystone_settings['protocol']}://#{keystone_settings['internal_url_host']}:#{keystone_settings['service_port']}/v3"
 
     eval $(openstack --os-token #{keystone_settings['admin_token']} \
         --os-url=$OS_URL \


### PR DESCRIPTION
We were not contacting the right hostname.
