### PR TITLE
Make config files owned by root:heat, instead of heat:root

### DIFF
--- a/chef/cookbooks/heat/attributes/default.rb
+++ b/chef/cookbooks/heat/attributes/default.rb
@@ -24,8 +24,7 @@ case node["platform"]
       :packages => ["heat-engine", "heat-api", "heat-api-cfn",
                     "heat-api-cloudwatch", "python-heat", "heat-common",
                     "python-heatclient"],
-      :services => ["heat-engine","heat-api","heat-api-cfn","heat-api-cloudwatch"],
-      :aux_dirs => ["/var/cache/heat","/etc/heat/environment.d"]
+      :services => ["heat-engine","heat-api","heat-api-cfn","heat-api-cloudwatch"]
     }
    when "suse"
     default[:heat][:platform] = {
@@ -33,8 +32,7 @@ case node["platform"]
                     "openstack-heat-api-cfn", "openstack-heat-api-cloudwatch",
                     "python-heatclient"],
       :services => ["openstack-heat-engine", "openstack-heat-api",
-                    "openstack-heat-api-cfn", "openstack-heat-api-cloudwatch"],
-      :aux_dirs => ["/var/cache/heat", "/etc/heat/environment.d"]
+                    "openstack-heat-api-cfn", "openstack-heat-api-cloudwatch"]
     }
     default[:heat][:engine][:service_name] = "openstack-heat-engine"
     default[:heat][:api][:service_name] = "openstack-heat-api"

--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -77,15 +77,19 @@ else
 
 end
 
-node[:heat][:platform][:aux_dirs].each do |d|
-  directory d do
-    owner node[:heat][:user]
-    group "root"
-    mode 00755
-    action :create
-  end
+directory "/var/cache/heat" do
+  owner node[:heat][:user]
+  group node[:heat][:group]
+  mode 00750
+  action :create
 end
 
+directory "/etc/heat/environment.d" do
+  owner "root"
+  group "root"
+  mode 00755
+  action :create
+end
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 


### PR DESCRIPTION
We don't want the heat user to be able to write the files.
