### PR TITLE
Fix fetching the ID of stack_user_domain when keystone is HA

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -251,7 +251,7 @@ end
 crowbar_pacemaker_sync_mark "create-heat_register"
 
 shell_get_stack_user_domain = <<-EOF
-  export OS_URL="#{KeystoneHelper.service_URL(node, node[:fqdn], node["keystone"]["api"]["service_port"])}/v3";
+  export OS_URL="#{keystone_settings['protocol']}://#{keystone_settings['internal_url_host']}:#{keystone_settings['service_port']}/v3"
   eval $(openstack --os-token #{keystone_settings['admin_token']} \
     --os-url=$OS_URL \
     --os-identity-api-version=3 domain show -f shell --variable id #{stack_user_domain_name});


### PR DESCRIPTION
(cherry picked from commit 2c10e38ed5fe6aa046e81e6a72e70e31f0422878)
