### PR TITLE
Fix creation of auth_encryption_key attribute on migration (bnc#892512)

### DIFF
--- a/chef/data_bags/crowbar/bc-template-heat.json
+++ b/chef/data_bags/crowbar/bc-template-heat.json
@@ -45,7 +45,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 13,
+      "schema-revision": 14,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/migrate/heat/011_add_auth_encryption_key.rb
+++ b/chef/data_bags/crowbar/migrate/heat/011_add_auth_encryption_key.rb
@@ -1,5 +1,12 @@
 def upgrade ta, td, a, d
-  a['auth_encryption_key'] = ta['auth_encryption_key']
+  # we use a class variable to set the same key in the proposal and in the
+  # role
+  unless defined?(@@heat_auth_encryption_key)
+    service = ServiceObject.new "fake-logger"
+    @@heat_auth_encryption_key = service.random_password
+  end
+
+  a['auth_encryption_key'] = @@heat_auth_encryption_key
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/heat/014_fix_auth_encryption_key.rb
+++ b/chef/data_bags/crowbar/migrate/heat/014_fix_auth_encryption_key.rb
@@ -1,0 +1,22 @@
+def upgrade ta, td, a, d
+  # we use a class variable to set the same key in the proposal and in the
+  # role
+  unless defined?(@@heat_auth_encryption_key)
+    if a['auth_encryption_key'].empty?
+      service = ServiceObject.new "fake-logger"
+      @@heat_auth_encryption_key = service.random_password
+    else
+      @@heat_auth_encryption_key = a['auth_encryption_key']
+    end
+  end
+
+  if a['auth_encryption_key'].empty?
+    a['auth_encryption_key'] = @@heat_auth_encryption_key
+  end
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  return a, d
+end


### PR DESCRIPTION
The template has an empty value which cannot work; we need to generate a
new value.  Since our previous migration was broken, we add a new one to
fix the setups that are already broken.

(cherry picked from commit 5b1ae3eb8879f3a42989c5ee9733298870913a0e)
