### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -212,7 +212,7 @@ keystone_register "register heat Cfn endpoint" do
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
   endpoint_service "heat"
-  endpoint_region "RegionOne"
+  endpoint_region keystone_settings['endpoint_region']
   endpoint_publicURL "#{node[:heat][:api][:protocol]}://#{my_public_host}:#{node[:heat][:api][:cfn_port]}/v1"
   endpoint_adminURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:cfn_port]}/v1"
   endpoint_internalURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:cfn_port]}/v1"
@@ -239,7 +239,7 @@ keystone_register "register heat endpoint" do
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
   endpoint_service "heat"
-  endpoint_region "RegionOne"
+  endpoint_region keystone_settings['endpoint_region']
   endpoint_publicURL "#{node[:heat][:api][:protocol]}://#{my_public_host}:#{node[:heat][:api][:port]}/v1/$(tenant_id)s"
   endpoint_adminURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:port]}/v1/$(tenant_id)s"
   endpoint_internalURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:port]}/v1/$(tenant_id)s"

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -100,7 +100,7 @@ heat_watch_server_url=<%= @heat_watch_server_url %>
 
 # Default region name used to get services endpoints. (string
 # value)
-#region_name_for_services=<None>
+region_name_for_services=<%= @keystone_settings['endpoint_region'] %>
 
 # Keystone role for heat template-defined users. (string
 # value)


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
