### PR TITLE
Replaced service for heat-cfn endpoint registration

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -214,7 +214,7 @@ keystone_register "register heat Cfn endpoint" do
   host keystone_settings['internal_url_host']
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
-  endpoint_service "heat"
+  endpoint_service "heat-cfn"
   endpoint_region "RegionOne"
   endpoint_publicURL "#{node[:heat][:api][:protocol]}://#{my_public_host}:#{node[:heat][:api][:cfn_port]}/v1"
   endpoint_adminURL "#{node[:heat][:api][:protocol]}://#{my_admin_host}:#{node[:heat][:api][:cfn_port]}/v1"


### PR DESCRIPTION
(cherry picked from commit e0b346f27a7d49599b79e43df8362b0635835099)
