### PR TITLE
Fix creation of stack_domain_admin_password on upgrade

### DIFF
--- a/chef/data_bags/crowbar/migrate/heat/013_add_heat_domain.rb
+++ b/chef/data_bags/crowbar/migrate/heat/013_add_heat_domain.rb
@@ -1,6 +1,14 @@
 def upgrade ta, td, a, d
+  # Password is created only at creation time, so we need to create one here.
+  # We use a class variable to set the same password in the proposal and in the
+  # role.
+  unless defined?(@@ceilometer_db_password)
+    service = ServiceObject.new "fake-logger"
+    @@stack_domain_admin_password = service.random_password
+  end
+
   a['stack_domain_admin'] = ta['stack_domain_admin']
-  a['stack_domain_admin_password'] = ta['stack_domain_admin_password']
+  a['stack_domain_admin_password'] = @@stack_domain_admin_password
   return a, d
 end
 


### PR DESCRIPTION
We don't want to use an empty password.
