### PR TITLE
Switch to trusts for managing delegation

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -156,6 +156,28 @@ keystone_register "add heat stack user role" do
   action :add_role
 end
 
+keystone_register "add heat stack owner role" do
+  protocol keystone_settings['protocol']
+  host keystone_settings['internal_url_host']
+  port keystone_settings['admin_port']
+  token keystone_settings['admin_token']
+  user_name keystone_settings['service_user']
+  tenant_name keystone_settings['service_tenant']
+  role_name "heat_stack_owner"
+  action :add_role
+end
+
+keystone_register "give admin access to stack owner role" do
+  protocol keystone_settings['protocol']
+  host keystone_settings['internal_url_host']
+  port keystone_settings['admin_port']
+  token keystone_settings['admin_token']
+  user_name keystone_settings['admin_user']
+  tenant_name keystone_settings['default_tenant']
+  role_name "heat_stack_owner"
+  action :add_access
+end
+
 package "python-openstackclient" do
   action :install
 end

--- a/chef/cookbooks/heat/templates/default/heat.conf.erb
+++ b/chef/cookbooks/heat/templates/default/heat.conf.erb
@@ -34,11 +34,11 @@ instance_user=<%= @instance_user %>
 
 # Select deferred auth method, stored password or trusts.
 # (string value)
-#deferred_auth_method=password
+deferred_auth_method=trusts
 
 # Subset of trustor roles to be delegated to heat. (list
 # value)
-#trusts_delegated_roles=heat_stack_owner
+trusts_delegated_roles=heat_stack_owner
 
 # Maximum resources allowed per top-level stack. (integer
 # value)


### PR DESCRIPTION
The previous default "passwords" is deprecated and actually
doesn't work when the passwords of all users are not identical. Like
it is in our case when we deploy with Crowbar. This fixes Heat
templates with autoscaling enabled.