### PR TITLE
Fix stack_domain_admin_password migration

### DIFF
--- a/chef/data_bags/crowbar/bc-template-heat.json
+++ b/chef/data_bags/crowbar/bc-template-heat.json
@@ -45,7 +45,7 @@
     "heat": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 14,
+      "schema-revision": 15,
       "element_states": {
         "heat-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/migrate/heat/013_add_heat_domain.rb
+++ b/chef/data_bags/crowbar/migrate/heat/013_add_heat_domain.rb
@@ -1,6 +1,12 @@
 def upgrade ta, td, a, d
+  # we use a class variable to set the same key in the proposal and in the
+  # role
   a['stack_domain_admin'] = ta['stack_domain_admin']
-  a['stack_domain_admin_password'] = ta['stack_domain_admin_password']
+  unless defined?(@@heat_stack_domain_admin_password)
+    service = ServiceObject.new "fake-logger"
+    @@heat_stack_domain_admin_password = service.random_password
+  end
+  a['stack_domain_admin_password'] = @@heat_stack_domain_admin_password
   return a, d
 end
 

--- a/chef/data_bags/crowbar/migrate/heat/015_fix_stack_domain_admin_password.rb
+++ b/chef/data_bags/crowbar/migrate/heat/015_fix_stack_domain_admin_password.rb
@@ -1,0 +1,22 @@
+def upgrade ta, td, a, d
+  # we use a class variable to set the same key in the proposal and in the
+  # role
+  unless defined?(@@heat_stack_domain_admin_password)
+    if a['stack_domain_admin_password'].empty?
+      service = ServiceObject.new "fake-logger"
+      @@heat_stack_domain_admin_password = service.random_password
+    else
+      @@heat_stack_domain_admin_password = a['stack_domain_admin_password']
+    end
+  end
+
+  if a['stack_domain_admin_password'].empty?
+    a['stack_domain_admin_password'] = @@heat_stack_domain_admin_password
+  end
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  return a, d
+end


### PR DESCRIPTION
We forgot to create a random password on migration. Add
a fixup migration to resolve issues with existing deployments.

(cherry picked from commit 3ff279f28692a0777ab18db8cb6ea9387d037b95)