### PR TITLE
HA: Set Mandatory ordering for Heat startup

### DIFF
--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -72,4 +72,11 @@ pacemaker_clone "cl-#{group_name}" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
+crowbar_pacemaker_order_only_existing "o-cl-#{group_name}" do
+  ordering [ "postgresql", "rabbitmq", "cl-keystone", "cl-g-nova-controller", "cl-#{group_name}" ]
+  score "Optional"
+  action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
 crowbar_pacemaker_sync_mark "create-heat_ha_resources"


### PR DESCRIPTION
Heat depends on Nova, Keystone and friends to be started first.