### PR TITLE
Avoid using the admin token (bnc#933731)

### DIFF
--- a/chef/cookbooks/heat/recipes/server.rb
+++ b/chef/cookbooks/heat/recipes/server.rb
@@ -256,7 +256,9 @@ bash "register heat domain" do
     fi
   EOF
   environment ({
-    'OS_TOKEN' => keystone_settings['admin_token'],
+    'OS_USERNAME' => keystone_settings['admin_user'],
+    'OS_PASSWORD' => keystone_settings['admin_password'],
+    'OS_TENANT_NAME' => keystone_settings['service_tenant'],
     'OS_URL' => "#{keystone_settings['protocol']}://#{keystone_settings['internal_url_host']}:#{keystone_settings['service_port']}/v3",
     'OS_REGION_NAME' => keystone_settings['endpoint_region'],
     'OS_IDENTITY_API_VERSION' => "3"


### PR DESCRIPTION
Using the admin token triggers a warning in the keystone
log, which is pointless. We can just authenticate as
admin instead.