### PR TITLE
increase timeout for synchronization of HA resources (bsc#935462)

### DIFF
--- a/chef/cookbooks/heat/recipes/ha.rb
+++ b/chef/cookbooks/heat/recipes/ha.rb
@@ -43,7 +43,9 @@ end.run_action(:create)
 crowbar_pacemaker_sync_mark "sync-heat_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-heat_ha_resources"
+crowbar_pacemaker_sync_mark "wait-heat_ha_resources" do
+  timeout 300
+end
 
 primitives = []
 


### PR DESCRIPTION
Heat HA resources can take over 1 minute to be set up, as
seen by mkcloud failures in ci.suse.de Jenkins.

Cherry-picked from ea6233b74128c08d674b5a355fd8a55cc15b11d7 (crowbar-openstack)
